### PR TITLE
fix(prefix): escape meta characters properly

### DIFF
--- a/prefix.gotmpl
+++ b/prefix.gotmpl
@@ -1,2 +1,2 @@
-{{ $e := execAdmin "prefix" }}{{ $prefix := reReplace `[*\\_\~]` (slice $e (add 15 (len (str .Guild.ID))) (sub (len $e) 1)) `\$0` }}
+{{ $e := execAdmin "prefix" }}{{ $prefix := reReplace `[\.\[\]\-\?\!\\\*\{\}\(\)\|\+\$\^]` (slice $e (add 15 (len (str .Guild.ID))) (sub (len $e) 1)) `\$0` }}
 {{ $prefix }}


### PR DESCRIPTION
Escaping all meta characters is feasible, as some might be using this snippet to perfom a prefix check in a custom command.

The merge conflicts have to be resolved manually on your end. Google will help you with that.

Kind regards